### PR TITLE
Flush output on each datum

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@ mod printer;
 mod reader;
 mod sexp;
 
+use std::io::Write;
+
 use parser::*;
 use printer::*;
 use reader::*;
@@ -16,6 +18,7 @@ fn main_inner() -> std::result::Result<(), Box<dyn std::error::Error>> {
 				let output = parse_form(s);
 				print_sexp(output);
 				println!();
+				std::io::stdout().flush()?;
 			}
 			None => {
 				break;

--- a/test/.results/latest.txt
+++ b/test/.results/latest.txt
@@ -6,10 +6,10 @@ UNIT TESTS... OK
 running 12 tests
 test parser::tests::test_parse_atom_1 ... ok
 test parser::tests::test_parse_atom_2 ... ok
-test parser::tests::test_parse_atom_3 ... ok
 test parser::tests::test_parse_atom_4 ... ok
-test parser::tests::test_parse_list_1 ... ok
+test parser::tests::test_parse_atom_3 ... ok
 test parser::tests::test_parse_atom_5 ... ok
+test parser::tests::test_parse_list_1 ... ok
 test reader::tests::test_form_reader_1 ... ok
 test reader::tests::test_form_reader_2 ... ok
 test reader::tests::test_form_reader_3 ... ok


### PR DESCRIPTION
Previously, we did not flush stdout on each datum.

This would cause issues in streaming mode where the stdout consumer expects datums to be emitted as soon as data arrives.

This PR flushes output on each datum.

Perhaps an additional flag can be provided for buffering input if needed in the future. This would be useful if performance is poor.
